### PR TITLE
fix(frontend): add missing Angular build builder

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -9,6 +9,7 @@
       "sourceRoot": "src",
       "architect": {
         "build": {
+          "builder": "@angular-devkit/build-angular:browser",
           "options": {
             "outputPath": "dist/frontend",
             "index": "src/index.html",


### PR DESCRIPTION
## Summary
- add missing `builder` setting to `angular.json`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686e9e0bdae08325abf9ae12b1f76a9e